### PR TITLE
CESU-8 label changed

### DIFF
--- a/pyhdb/auth.py
+++ b/pyhdb/auth.py
@@ -78,7 +78,7 @@ class AuthManager(object):
 
         key = hashlib.sha256(
             hmac.new(
-                self.password.encode('cesu-8'), salt, hashlib.sha256
+                self.password.encode('cesu8'), salt, hashlib.sha256
             ).digest()
         ).digest()
         key_hash = hashlib.sha256(key).digest()

--- a/pyhdb/cesu8.py
+++ b/pyhdb/cesu8.py
@@ -141,7 +141,7 @@ class StreamReader(codecs.StreamReader):
 
 
 CESU8_CODEC_INFO = codecs.CodecInfo(
-    name="cesu-8",
+    name="cesu8",
     encode=encode,
     decode=decode,
     incrementalencoder=IncrementalEncoder,
@@ -152,7 +152,7 @@ CESU8_CODEC_INFO = codecs.CodecInfo(
 
 
 def search_function(encoding):
-    if encoding == 'cesu-8':
+    if encoding == 'cesu8':
         return CESU8_CODEC_INFO
     else:
         return None

--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -45,7 +45,7 @@ class Fields(object):
         payload = struct.pack('<H', len(fields))
         for field in fields:
             if is_text(field):
-                field = field.encode('cesu-8')
+                field = field.encode('cesu8')
 
             size = len(field)
             if size >= 250:
@@ -168,13 +168,13 @@ class Command(Part):
         self.sql_statement = sql_statement
 
     def pack_data(self, remaining_size):
-        payload = self.sql_statement.encode('cesu-8')
+        payload = self.sql_statement.encode('cesu8')
         return 1, payload
 
     @classmethod
     def unpack_data(cls, argument_count, payload):
         sql_statement = payload.read()
-        return sql_statement.decode('cesu-8')
+        return sql_statement.decode('cesu8')
 
 
 class ResultSet(Part):

--- a/pyhdb/protocol/types.py
+++ b/pyhdb/protocol/types.py
@@ -277,7 +277,7 @@ class MixinStringType(object):
         length = MixinStringType.get_length(payload)
         if length is None:
             return None
-        return payload.read(length).decode('cesu-8')
+        return payload.read(length).decode('cesu8')
 
     @classmethod
     def prepare(cls, value, type_code=type_codes.CHAR):
@@ -289,7 +289,7 @@ class MixinStringType(object):
             if not isinstance(value, string_types):
                 # Value is provided e.g. as integer, but a string is actually required. Try proper casting into string:
                 value = text_type(value)
-            value = value.encode('cesu-8')
+            value = value.encode('cesu8')
             length = len(value)
             # length indicator
             if length <= 245:

--- a/tests/parts/test_clientid.py
+++ b/tests/parts/test_clientid.py
@@ -21,7 +21,7 @@ def test_pack_data():
     part = ClientId("bla@example.com")
     arguments, payload = part.pack_data(constants.MAX_SEGMENT_SIZE)
     assert arguments == 1
-    assert payload == "bla@example.com".encode('cesu-8')
+    assert payload == "bla@example.com".encode('cesu8')
 
 
 def test_unpack_data():

--- a/tests/test_cesu8.py
+++ b/tests/test_cesu8.py
@@ -29,7 +29,7 @@ import pyhdb.cesu8  # import required to register cesu8 encoding
     (b"\xed\xa0\xbf\xed\xbc\x84", u"\U0001FF04"),
 ])
 def test_pure_cesu8_decode(encoded, unicode_obj):
-    assert encoded.decode('cesu-8') == unicode_obj
+    assert encoded.decode('cesu8') == unicode_obj
 
 
 @pytest.mark.parametrize("encoded,unicode_obj", [
@@ -37,18 +37,18 @@ def test_pure_cesu8_decode(encoded, unicode_obj):
     (b"\xe2\xac\xa1", u"\u2b21"),
 ])
 def test_fallback_to_utf8_of_cesu8_decode(encoded, unicode_obj):
-    assert encoded.decode('cesu-8') == unicode_obj
+    assert encoded.decode('cesu8') == unicode_obj
 
 
 def test_multiple_chars_in_cesu8_decode():
     encoded = b"\xed\xa0\xbd\xed\xb0\x8d\xed\xa0\xbd\xed\xb1\x8d"
-    assert encoded.decode('cesu-8') == u'\U0001f40d\U0001f44d'
+    assert encoded.decode('cesu8') == u'\U0001f40d\U0001f44d'
 
 
 def test_cesu8_and_utf8_mixed_decode():
     encoded = b"\xed\xa0\xbd\xed\xb0\x8d\x20\x69\x73\x20\x61\x20" \
               b"\xcf\x86\xce\xaf\xce\xb4\xce\xb9"
-    assert encoded.decode('cesu-8') == \
+    assert encoded.decode('cesu8') == \
         u'\U0001f40d is a \u03c6\u03af\u03b4\u03b9'
 
 
@@ -63,7 +63,7 @@ def test_cesu8_and_utf8_mixed_decode():
     (b"\xed\xa0\xbf\xed\xbc\x84", u"\U0001FF04"),
 ])
 def test_pure_cesu8_encode(encoded, unicode_obj):
-    assert unicode_obj.encode('cesu-8') == encoded
+    assert unicode_obj.encode('cesu8') == encoded
 
 
 @pytest.mark.parametrize("encoded,unicode_obj", [
@@ -71,22 +71,22 @@ def test_pure_cesu8_encode(encoded, unicode_obj):
     (b"\xe2\xac\xa1", u"\u2b21"),
 ])
 def test_fallback_to_utf8_encode(encoded, unicode_obj):
-    assert unicode_obj.encode('cesu-8') == encoded
+    assert unicode_obj.encode('cesu8') == encoded
 
 
 def test_multiple_chars_in_cesu8_encode():
     encoded = b"\xed\xa0\xbd\xed\xb0\x8d\xed\xa0\xbd\xed\xb1\x8d"
-    assert u'\U0001f40d\U0001f44d'.encode('cesu-8') == encoded
+    assert u'\U0001f40d\U0001f44d'.encode('cesu8') == encoded
 
 
 def test_cesu8_and_utf8_mixed_encode():
     encoded = b"\xed\xa0\xbd\xed\xb0\x8d\x20\x69\x73\x20\x61\x20" \
               b"\xcf\x86\xce\xaf\xce\xb4\xce\xb9"
-    assert u'\U0001f40d is a \u03c6\u03af\u03b4\u03b9'.encode('cesu-8') == \
+    assert u'\U0001f40d is a \u03c6\u03af\u03b4\u03b9'.encode('cesu8') == \
         encoded
 
 def test_cesu8_and_utf8_mixed_encode_decode():
     unicode_input = u'Some normal text with 😊 and other emojis like 🤔 or 🤖'
-    cesu8_encoded = unicode_input.encode('cesu-8')
-    decoded_unicode = cesu8_encoded.decode('cesu-8')
+    cesu8_encoded = unicode_input.encode('cesu8')
+    decoded_unicode = cesu8_encoded.decode('cesu8')
     assert decoded_unicode == unicode_input

--- a/tests/types/test_string.py
+++ b/tests/types/test_string.py
@@ -37,13 +37,13 @@ def test_unpack_string(given, expected):
 
 def test_unpack_long_string():
     text = u'%030x' % random.randrange(16**300)
-    given = BytesIO(b"\xF6\x2C\x01" + text.encode('cesu-8'))
+    given = BytesIO(b"\xF6\x2C\x01" + text.encode('cesu8'))
     assert types.String.from_resultset(given) == text
 
 
 def test_unpack_very_long_string():
     text = u'%030x' % random.randrange(16**30000)
-    given = BytesIO(b"\xF7\x30\x75\x00\x00" + text.encode('cesu-8'))
+    given = BytesIO(b"\xF7\x30\x75\x00\x00" + text.encode('cesu8'))
     assert types.String.from_resultset(given) == text
 
 
@@ -99,13 +99,13 @@ def test_pack_string(given, expected):
 def test_pack_long_string():
     text = b'\xe6\x9c\xb1' * 3500
     expected = b"\x08\xF6\x04\x29" + text
-    assert types.String.prepare(text.decode('cesu-8')) == expected
+    assert types.String.prepare(text.decode('cesu8')) == expected
 
 
 def test_pack_very_long_string():
     text = b'\xe6\x9c\xb1' * 35000
     expected = b"\x08\xF7\x28\x9a\x01\x00" + text
-    assert types.String.prepare(text.decode('cesu-8')) == expected
+    assert types.String.prepare(text.decode('cesu8')) == expected
 
 
 # #############################################################################################################


### PR DESCRIPTION
To support codecs.register()'s requirement (the encoding name in all lower case letters), change the CESU-8 label (encoding name) from 'cesu-8' to 'cesu8'.